### PR TITLE
Enable multi-answer questions and improved review pool logic

### DIFF
--- a/client/src/components/feedback-modal.tsx
+++ b/client/src/components/feedback-modal.tsx
@@ -13,10 +13,12 @@ interface FeedbackData {
   correct: boolean;
   explanation: string;
   correctAnswer?: string;
+  correctAnswers?: string[];
   retryQuestion?: {
     text: string;
     options?: Array<{ id: string; text: string; correct: boolean }>;
     correctAnswer?: string;
+    correctAnswers?: string[];
   };
   sourceFile?: string;
   topic?: string;
@@ -116,16 +118,16 @@ export function FeedbackModal({
               </DialogDescription>
             </DialogHeader>
 
-            {feedback.correctAnswer && (
+            {(feedback.correctAnswer || feedback.correctAnswers) && (
               <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-4 mt-4">
                 <h4 className="font-medium text-red-800 mb-2">
-                  Richtige Antwort:
+                  Richtige Antwort{feedback.correctAnswers && feedback.correctAnswers.length > 1 ? 'en' : ''}:
                 </h4>
                 <p
                   className="text-sm text-red-700"
                   data-testid="feedback-correct-answer"
                 >
-                  {feedback.correctAnswer}
+                  {feedback.correctAnswer || feedback.correctAnswers?.join(', ')}
                 </p>
               </div>
             )}

--- a/client/src/components/file-upload.tsx
+++ b/client/src/components/file-upload.tsx
@@ -201,8 +201,8 @@ export function FileUpload({ onFileUpload, isLoading }: FileUploadProps) {
           </ToggleGroupItem>
         </ToggleGroup>
         <p className="text-xs text-gray-500">
-          Davon ca. {Math.round(totalQuestions / 3)} neue und{" "}
-          {totalQuestions - Math.round(totalQuestions / 3)} Wiederholungsfragen.
+          Davon ca. {Math.round(totalQuestions / 2)} neue und{" "}
+          {totalQuestions - Math.round(totalQuestions / 2)} Wiederholungsfragen.
           Falls nicht genügend Wiederholungsfragen vorhanden sind, werden neue
           Fragen ergänzt.
         </p>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -60,6 +60,7 @@ interface FeedbackData {
   correct: boolean;
   explanation: string;
   correctAnswer?: string;
+  correctAnswers?: string[];
   sourceFile?: string;
   topic?: string;
 }
@@ -164,12 +165,15 @@ export default function Home() {
       answer,
     }: {
       questionId: string;
-      answer: string;
+      answer: string | string[];
     }) => {
+      const body = Array.isArray(answer)
+        ? { questionId, answers: answer }
+        : { questionId, answer };
       const response = await fetch(`/api/quiz/${sessionId}/answer`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ questionId, answer }),
+        body: JSON.stringify(body),
       });
 
       if (!response.ok) {
@@ -244,7 +248,7 @@ export default function Home() {
     }
   };
 
-  const handleAnswerSubmit = (answer: string) => {
+  const handleAnswerSubmit = (answer: string | string[]) => {
     if (!quizSession) return;
 
     const currentQuestion = getCurrentQuestion();

--- a/server/csvStorage.ts
+++ b/server/csvStorage.ts
@@ -367,7 +367,7 @@ export class CSVStorage implements IStorage {
 
       const stats = new Map<
         number,
-        { correctCount: number; timesAsked: number; lastCorrect: boolean }
+        { everIncorrect: boolean; correctStreak: number; timesAsked: number; lastCorrect: boolean }
       >();
       for (const line of usageLines) {
         const fields = parseCSVLine(line);
@@ -376,13 +376,19 @@ export class CSVStorage implements IStorage {
 
         if (!isNaN(storedQuestionId)) {
           const entry = stats.get(storedQuestionId) || {
-            correctCount: 0,
+            everIncorrect: false,
+            correctStreak: 0,
             timesAsked: 0,
             lastCorrect: false,
           };
           entry.timesAsked += 1;
           entry.lastCorrect = wasCorrect;
-          if (wasCorrect) entry.correctCount += 1;
+          if (wasCorrect) {
+            entry.correctStreak += 1;
+          } else {
+            entry.correctStreak = 0;
+            entry.everIncorrect = true;
+          }
           stats.set(storedQuestionId, entry);
         }
       }
@@ -395,9 +401,9 @@ export class CSVStorage implements IStorage {
         const questionId = Number(fields[0]);
         const stat = stats.get(questionId);
 
-        // Include only questions that have been answered (present in usage) and
-        // have fewer than two total correct answers
-        if (stat && stat.correctCount < 2) {
+        // Include only questions that were answered incorrectly at least once
+        // and have fewer than two consecutive correct answers
+        if (stat && stat.everIncorrect && stat.correctStreak < 2) {
           const question: Question = {
             id: `stored_${fields[0]}`,
             type: fields[3] as QuestionType,
@@ -411,7 +417,7 @@ export class CSVStorage implements IStorage {
             isReviewQuestion: true,
             timesAsked: stat.timesAsked,
             lastCorrect: stat.lastCorrect,
-            correctRemaining: Math.max(0, 2 - stat.correctCount),
+            correctRemaining: Math.max(0, 2 - stat.correctStreak),
           };
           reviewQuestions.push(question);
 
@@ -441,25 +447,30 @@ export class CSVStorage implements IStorage {
       const usageContent = await fs.readFile(FILES.usage, 'utf-8');
       const usageLines = usageContent.trim().split('\n').slice(1);
 
-      const correctCounts = new Map<number, number>();
+      const stats = new Map<number, { everIncorrect: boolean; correctStreak: number }>();
       for (const line of usageLines) {
         const fields = parseCSVLine(line);
         const storedQuestionId = Number(fields[2]);
         const wasCorrect = fields[3] === 'true';
 
         if (!isNaN(storedQuestionId)) {
-          const current = correctCounts.get(storedQuestionId) || 0;
+          const entry = stats.get(storedQuestionId) || {
+            everIncorrect: false,
+            correctStreak: 0,
+          };
           if (wasCorrect) {
-            correctCounts.set(storedQuestionId, current + 1);
-          } else if (!correctCounts.has(storedQuestionId)) {
-            correctCounts.set(storedQuestionId, 0);
+            entry.correctStreak += 1;
+          } else {
+            entry.correctStreak = 0;
+            entry.everIncorrect = true;
           }
+          stats.set(storedQuestionId, entry);
         }
       }
 
       let total = 0;
-      for (const count of Array.from(correctCounts.values())) {
-        if (count < 2) total++;
+      for (const entry of Array.from(stats.values())) {
+        if (entry.everIncorrect && entry.correctStreak < 2) total++;
       }
 
       return { total };


### PR DESCRIPTION
## Summary
- Allow up to four correct answers per question with checkbox selection and feedback for multiple solutions
- Rework review pool to include only incorrect questions and require two consecutive correct answers to exit
- Balance quizzes with a 50/50 split between new and review questions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a60b9fa9a0832c8655bfded3c7598c