### PR TITLE
Add offline practice mode using stored questions

### DIFF
--- a/client/src/components/feedback-modal.tsx
+++ b/client/src/components/feedback-modal.tsx
@@ -27,6 +27,7 @@ interface FeedbackModalProps {
   feedback: FeedbackData;
   onClose: () => void;
   onNext: () => void;
+  onExit?: () => void;
 }
 
 export function FeedbackModal({
@@ -34,6 +35,7 @@ export function FeedbackModal({
   feedback,
   onClose,
   onNext,
+  onExit,
 }: FeedbackModalProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onNext}>
@@ -98,6 +100,16 @@ export function FeedbackModal({
               <ArrowRight className="mr-2 h-4 w-4" />
               Nächste Frage
             </Button>
+            {onExit && (
+              <Button
+                onClick={onExit}
+                variant="outline"
+                className="w-full mt-2"
+                data-testid="button-exit-quiz"
+              >
+                Modus beenden
+              </Button>
+            )}
           </div>
         ) : (
           <div className="text-center">
@@ -171,6 +183,16 @@ export function FeedbackModal({
               <ArrowRight className="mr-2 h-4 w-4" />
               Weiter
             </Button>
+            {onExit && (
+              <Button
+                onClick={onExit}
+                variant="outline"
+                className="w-full mt-2"
+                data-testid="button-exit-quiz"
+              >
+                Modus beenden
+              </Button>
+            )}
           </div>
         )}
       </DialogContent>

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -222,6 +222,18 @@ export default function Home() {
     },
   });
 
+  const practiceMutation = useMutation({
+    mutationFn: async () => {
+      const response = await fetch("/api/practice/start", {
+        method: "POST",
+      });
+      if (!response.ok) {
+        throw new Error("Practice mode konnte nicht gestartet werden");
+      }
+      return response.json() as Promise<{ sessionId: string }>;
+    },
+  });
+
   const handleFileUpload = async (
     files: File[],
     questionTypes: QuestionType[],
@@ -247,6 +259,11 @@ export default function Home() {
     } finally {
       setIsGenerating(false);
     }
+  };
+
+  const handleStartPractice = async () => {
+    const result = await practiceMutation.mutateAsync();
+    window.location.href = `/quiz/${result.sessionId}`;
   };
 
   const handleAnswerSubmit = (answer: string[]) => {
@@ -278,6 +295,13 @@ export default function Home() {
   };
 
   const handleStartNew = () => {
+    window.location.href = "/";
+  };
+
+  const handleExitQuiz = () => {
+    if (sessionId) {
+      progressMutation.mutate({ completed: true });
+    }
     window.location.href = "/";
   };
 
@@ -462,6 +486,7 @@ export default function Home() {
               feedback={feedbackData}
               onClose={() => setShowFeedback(false)}
               onNext={handleNextQuestion}
+              onExit={handleExitQuiz}
             />
           )}
         </main>
@@ -533,6 +558,13 @@ export default function Home() {
                   onFileUpload={handleFileUpload}
                   isLoading={uploadMutation.isPending}
                 />
+                <Button
+                  onClick={handleStartPractice}
+                  className="mt-4"
+                  disabled={practiceMutation.isPending}
+                >
+                  Offline-Modus starten
+                </Button>
               </div>
             </CardContent>
           </Card>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -451,6 +451,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Start practice mode with random existing questions
+  app.post("/api/practice/start", async (_req, res) => {
+    try {
+      const questions = await storage.getRandomQuestions(Number.MAX_SAFE_INTEGER);
+      const session = await storage.createQuizSession({
+        summaryText: "Offline-Modus",
+        questions,
+      });
+      res.json({ sessionId: session.id });
+    } catch (error: any) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+
   // Review pool stats
   app.get("/api/review-pool/stats", async (_req, res) => {
     try {


### PR DESCRIPTION
## Summary
- add storage helper to fetch random stored questions
- expose `/api/practice/start` endpoint to launch offline mode sessions
- provide offline mode button and exit option in feedback modal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68ab1049d6dc832c90efae4e1266ac46